### PR TITLE
Untitled

### DIFF
--- a/backup/moodle2/backup_book_activity_task.class.php
+++ b/backup/moodle2/backup_book_activity_task.class.php
@@ -67,21 +67,21 @@ class backup_book_activity_task extends backup_activity_task {
 
         // Link to the list of books
         $search  = "/(".$base."\/mod\/book\/index.php\?id\=)([0-9]+)/";
-        $content = preg_replace($search, '$@bookINDEX*$2@$', $content);
+        $content = preg_replace($search, '$@BOOKINDEX*$2@$', $content);
 
         // Link to book view by moduleid
         $search  = "/(".$base."\/mod\/book\/view.php\?id\=)([0-9]+)/";
-        $content = preg_replace($search, '$@bookVIEWBYID*$2@$', $content);
+        $content = preg_replace($search, '$@BOOKVIEWBYID*$2@$', $content);
 
         $search  = "/(".$base."\/mod\/book\/view.php\?id\=)([0-9]+)&chapterid=([0-9]+)/";
-        $content = preg_replace($search, '$@bookVIEWBYIDCH*$2*$3@$', $content);
+        $content = preg_replace($search, '$@BOOKVIEWBYIDCH*$2*$3@$', $content);
 
         // Link to book view by bookid
         $search  = "/(".$base."\/mod\/book\/view.php\?b\=)([0-9]+)/";
-        $content = preg_replace($search, '$@bookVIEWBYB*$2@$', $content);
+        $content = preg_replace($search, '$@BOOKVIEWBYB*$2@$', $content);
 
         $search  = "/(".$base."\/mod\/book\/view.php\?b\=)([0-9]+)&chapterid=([0-9]+)/";
-        $content = preg_replace($search, '$@bookVIEWBYBCH*$2*$3@$', $content);
+        $content = preg_replace($search, '$@BOOKVIEWBYBCH*$2*$3@$', $content);
 
         return $content;
     }

--- a/backup/moodle2/restore_book_activity_task.class.php
+++ b/backup/moodle2/restore_book_activity_task.class.php
@@ -78,15 +78,15 @@ class restore_book_activity_task extends restore_activity_task {
         $rules = array();
 
         // List of books in course
-        $rules[] = new restore_decode_rule('bookINDEX', '/mod/book/index.php?id=$1', 'course');
+        $rules[] = new restore_decode_rule('BOOKINDEX', '/mod/book/index.php?id=$1', 'course');
 
         // book by cm->id
-        $rules[] = new restore_decode_rule('bookVIEWBYID', '/mod/book/view.php?id=$1', 'course_module');
-        $rules[] = new restore_decode_rule('bookVIEWBYIDCH', '/mod/book/view.php?id=$1&chapterid=$2', array('course_module', 'book_chapter'));
+        $rules[] = new restore_decode_rule('BOOKVIEWBYID', '/mod/book/view.php?id=$1', 'course_module');
+        $rules[] = new restore_decode_rule('BOOKVIEWBYIDCH', '/mod/book/view.php?id=$1&chapterid=$2', array('course_module', 'book_chapter'));
 
         // book by book->id
-        $rules[] = new restore_decode_rule('bookVIEWBYB', '/mod/book/view.php?b=$1', 'book');
-        $rules[] = new restore_decode_rule('bookVIEWBYBCH', '/mod/book/view.php?b=$1&chapterid=$2', array('book', 'book_chapter'));
+        $rules[] = new restore_decode_rule('BOOKVIEWBYB', '/mod/book/view.php?b=$1', 'book');
+        $rules[] = new restore_decode_rule('BOOKVIEWBYBCH', '/mod/book/view.php?b=$1&chapterid=$2', array('book', 'book_chapter'));
 
         return $rules;
     }


### PR DESCRIPTION
Importing activities from one course to another fails, an exception is thrown:

line 140 of /backup/util/helper/restore_decode_rule.class.php: restore_decode_rule_exception thrown
line 49 of /backup/util/helper/restore_decode_rule.class.php: call to restore_decode_rule->validate_params()
line 81 of /mod/book/backup/moodle2/restore_book_activity_task.class.php: call to restore_decode_rule->__construct()
line ? of unknownfile: call to restore_book_activity_task::define_decode_rules()
line 143 of /backup/util/helper/restore_decode_processor.class.php: call to call_user_func()
line 353 of /backup/moodle2/restore_stepslib.php: call to restore_decode_processor::register_link_decoders()
line 34 of /backup/util/plan/restore_execution_step.class.php: call to restore_decode_interlinks->define_execution()
line 153 of /backup/util/plan/base_task.class.php: call to restore_execution_step->execute()
line 148 of /backup/util/plan/base_plan.class.php: call to base_task->execute()
line 157 of /backup/util/plan/restore_plan.class.php: call to base_plan->execute()
line 299 of /backup/controller/restore_controller.class.php: call to restore_plan->execute()

This is due to the decode rule names being in an unexpected format, this patch fixes the decode rules, and changes the encode rules to match.
